### PR TITLE
概要：Search and sort

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,11 @@
 exit
+@unlisted_items
+@listed_items
+@q
+@category
+exit
+@category
+exit
 @total_disposed_items.to_f/@decluttering.goal_amount*100
 @total_disposed_items.to_f/@decluttering.goal_amount
 @total_disposed_items/@decluttering.goal_amount

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem "carrierwave"
 gem "mini_magick"
 
 # 検索機能
-gem "ransack"
+gem "ransack", "3.2.1"
 
 # 変数をjsに渡す
 gem "gon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (4.1.0)
+    ransack (3.2.1)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
@@ -370,7 +370,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (= 7.0.6)
   rails-i18n
-  ransack
+  ransack (= 3.2.1)
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,6 @@ class ApplicationController < ActionController::Base
       @q_header = Post.ransack(params[:q])
     when 'posts#likes'
       @q_header = current_user.like_posts.ransack(params[:q])
-    else
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,27 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+  before_action :set_search
 
   private
 
   def not_authenticated
     redirect_to login_path, alert: "Please login first"
+  end
+
+  def set_search
+    case "#{params[:controller]}##{params[:action]}"
+    when 'items#index'
+      @category = current_user.categories.find(params[:category_id])
+      @q_header = @category.items.ransack(params[:q])
+    when 'items#history'
+      @q_header = current_user.items.ransack(params[:q])
+    when 'categories#index'
+      @q_header = current_user.categories.ransack(params[:q])
+    when 'posts#index'
+      @q_header = Post.ransack(params[:q])
+    when 'posts#likes'
+      @q_header = current_user.like_posts.ransack(params[:q])
+    else
+    end
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -6,6 +6,13 @@ class CategoriesController < ApplicationController
     @categories = @q.result(distinct: true)
   end
 
+  def search
+    @categories = current_user.categories.where("title like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   def new
     @category = Category.new
   end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,8 +2,7 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: [:edit, :update, :destroy]
 
   def index
-    @q = current_user.categories.ransack(params[:q])
-    @categories = @q.result(distinct: true)
+    @categories = @q_header.result(distinct: true) if @q_header
   end
 
   def search

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,8 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: [:edit, :update, :destroy]
 
   def index
-    @categories = Category.where(user_id: current_user.id)
+    @q = current_user.categories.ransack(params[:q])
+    @categories = @q.result(distinct: true)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_categories, only: [:new, :create, :edit, :update]
 
   def index
-    before_items = @q_header.result(distinct: true).includes(:user).where(disposal_method: 0) if @q_header
+    before_items = @q_header.result(distinct: true).select('items.*, notifications.notify_date').joins(:notification).where(disposal_method: 0) if @q_header
     @listed_items = before_items.where(listing_status: true)
     @unlisted_items = before_items.where(listing_status: false)
   end
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
   end
 
   def history
-    @disposal_items = @q_header.result(distinct: true).includes(:user).where.not(disposal_method: 0) if @q_header
+    @disposal_items = @q_header.result(distinct: true).select('items.*, notifications.notify_date').joins(:notification).where.not(disposal_method: 0) if @q_header
   end
 
   def chart

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,8 +6,9 @@ class ItemsController < ApplicationController
     return unless params[:category_id].present?
 
     @category = current_user.categories.find(params[:category_id])
-    @listed_items = @category.items.includes(:user).where(listing_status: true, disposal_method: 0)
-    @unlisted_items = @category.items.includes(:user).where(listing_status: false, disposal_method: 0)
+    @q = @category.items.ransack(params[:q])
+    @listed_items = @q.result(distinct: true).includes(:user).where(listing_status: true, disposal_method: 0)
+    @unlisted_items = @q.result(distinct: true).includes(:user).where(listing_status: false, disposal_method: 0)
   end
 
   def show; end
@@ -29,7 +30,8 @@ class ItemsController < ApplicationController
   end
 
   def history
-    @disposal_items = current_user.items.includes(:user).where.not(disposal_method: 0)
+    @q = current_user.items.ransack(params[:q])
+    @disposal_items = @q.result(distinct: true).includes(:user).where.not(disposal_method: 0)
   end
 
   def chart

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,10 +3,9 @@ class ItemsController < ApplicationController
   before_action :set_categories, only: [:new, :create, :edit, :update]
 
   def index
-    @category = current_user.categories.find(params[:category_id])
-    @q = @category.items.ransack(params[:q])
-    @listed_items = @q.result(distinct: true).includes(:user).where(listing_status: true, disposal_method: 0)
-    @unlisted_items = @q.result(distinct: true).includes(:user).where(listing_status: false, disposal_method: 0)
+    before_items = @q_header.result(distinct: true).includes(:user).where(disposal_method: 0) if @q_header
+    @listed_items = before_items.where(listing_status: true)
+    @unlisted_items = before_items.where(listing_status: false)
   end
 
   def search
@@ -39,8 +38,7 @@ class ItemsController < ApplicationController
   end
 
   def history
-    @q = current_user.items.ransack(params[:q])
-    @disposal_items = @q.result(distinct: true).includes(:user).where.not(disposal_method: 0)
+    @disposal_items = @q_header.result(distinct: true).includes(:user).where.not(disposal_method: 0) if @q_header
   end
 
   def chart

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,11 @@ class ItemsController < ApplicationController
   end
 
   def search
-    @items = current_user.items.where.not(disposal_method: 0).where("name like ?", "%#{params[:q]}%")
+    if params[:view] == 'history'
+      @items = current_user.items.where.not(disposal_method: 0).where("name like ?", "%#{params[:q]}%")
+    elsif params[:view] == 'index'
+      @items = current_user.items.where(disposal_method: 0).where("name like ?", "%#{params[:q]}%")
+    end
     respond_to do |format|
       format.js
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,6 @@ class ItemsController < ApplicationController
   before_action :set_categories, only: [:new, :create, :edit, :update]
 
   def index
-    return unless params[:category_id].present?
-
     @category = current_user.categories.find(params[:category_id])
     @q = @category.items.ransack(params[:q])
     @listed_items = @q.result(distinct: true).includes(:user).where(listing_status: true, disposal_method: 0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,13 @@ class ItemsController < ApplicationController
     @unlisted_items = @q.result(distinct: true).includes(:user).where(listing_status: false, disposal_method: 0)
   end
 
+  def search
+    @items = current_user.items.where.not(disposal_method: 0).where("name like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   def show; end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,9 @@ class ItemsController < ApplicationController
   before_action :set_categories, only: [:new, :create, :edit, :update]
 
   def index
-    before_items = @q_header.result(distinct: true).select('items.*, notifications.notify_date').joins(:notification).where(disposal_method: 0) if @q_header
+    if @q_header
+      before_items = @q_header.result(distinct: true).select('items.*, notifications.notify_date').joins(:notification).where(disposal_method: 0)
+    end
     @listed_items = before_items.where(listing_status: true)
     @unlisted_items = before_items.where(listing_status: false)
   end
@@ -38,7 +40,9 @@ class ItemsController < ApplicationController
   end
 
   def history
-    @disposal_items = @q_header.result(distinct: true).select('items.*, notifications.notify_date').joins(:notification).where.not(disposal_method: 0) if @q_header
+    return unless @q_header
+
+    @disposal_items = @q_header.result(distinct: true).select('items.*, notifications.notify_date').joins(:notification).where.not(disposal_method: 0)
   end
 
   def chart

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,8 @@ class PostsController < ApplicationController
   before_action :set_disposal, only: [:new, :create, :edit, :update]
 
   def index
-    @posts = Post.all.includes(:user).order(created_at: :desc)
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
   end
 
   def show
@@ -42,7 +43,8 @@ class PostsController < ApplicationController
   end
 
   def likes
-    @like_posts = current_user.like_posts.includes(:user).order(created_at: :desc)
+    @q = current_user.like_posts.ransack(params[:q])
+    @like_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,8 @@ class PostsController < ApplicationController
   before_action :set_disposal, only: [:new, :create, :edit, :update]
 
   def index
-    @posts = @q_header.result(distinct: true).includes(:user).order(created_at: :desc) if @q_header
+    # distinct: trueではsort_linkでエラーになるため
+    @posts = @q_header.result.group('posts.id').includes([:user, :likes, :item]).order(created_at: :desc) if @q_header
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,8 +3,7 @@ class PostsController < ApplicationController
   before_action :set_disposal, only: [:new, :create, :edit, :update]
 
   def index
-    @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+    @posts = @q_header.result(distinct: true).includes(:user).order(created_at: :desc) if @q_header
   end
 
   def show
@@ -43,8 +42,14 @@ class PostsController < ApplicationController
   end
 
   def likes
-    @q = current_user.like_posts.ransack(params[:q])
-    @like_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+    @like_posts = @q_header.result(distinct: true).includes(:user).order(created_at: :desc) if @q_header
+  end
+
+  def search
+    @posts = Post.where("advice like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,13 +46,6 @@ class PostsController < ApplicationController
     @like_posts = @q_header.result(distinct: true).includes(:user).order(created_at: :desc) if @q_header
   end
 
-  def search
-    @posts = Post.where("advice like ?", "%#{params[:q]}%")
-    respond_to do |format|
-      format.js
-    end
-  end
-
   private
 
   def post_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,55 @@
 module ApplicationHelper
+  def set_url(category = nil)
+    if category && current_page?(category_items_path(category))
+      category_items_path(category)
+    elsif current_page?(history_items_path)
+      history_items_path
+    elsif current_page?(categories_path)
+      categories_path
+    elsif current_page?(posts_path)
+      posts_path
+    elsif current_page?(likes_posts_path)
+      likes_posts_path
+    end
+  end
+
+  def set_value(category = nil)
+    if category && current_page?(category_items_path(category))
+      search_items_path(view: 'index')
+    elsif current_page?(history_items_path)
+      search_items_path(view: 'history')
+    elsif current_page?(categories_path)
+      search_categories_path
+    elsif current_page?(posts_path)
+      search_posts_path
+    end
+  end
+
+  def set_search_key(category = nil)
+    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+      :name_cont
+    elsif current_page?(categories_path)
+      :title_cont
+    elsif current_page?(posts_path) || current_page?(likes_posts_path)
+      :advice_cont
+    end
+  end
+
+  def set_key(category = nil)
+    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+      :name
+    elsif current_page?(categories_path)
+      :title
+    elsif current_page?(posts_path) || current_page?(likes_posts_path)
+      :advice
+    end
+  end
+
+  def choice_page?(category = nil)
+    category && current_page?(category_items_path(category)) ||
+    current_page?(history_items_path) ||
+    current_page?(categories_path) ||
+    current_page?(posts_path) ||
+    current_page?(likes_posts_path)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,4 +52,20 @@ module ApplicationHelper
     current_page?(posts_path) ||
     current_page?(likes_posts_path)
   end
+
+  def set_diposal_key(category = nil)
+    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+      :disposal_method_eq
+    elsif current_page?(posts_path) || current_page?(likes_posts_path)
+      :item_disposal_method_eq
+    end
+  end
+
+  def set_listing_key(category = nil)
+    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+      :listing_status_eq
+    elsif current_page?(posts_path) || current_page?(likes_posts_path)
+      :item_listing_status_eq
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
   end
 
   def set_search_key(category = nil)
-    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+    if (category && current_page?(category_items_path(category))) || current_page?(history_items_path)
       :name_cont
     elsif current_page?(categories_path)
       :title_or_items_name_cont
@@ -36,7 +36,7 @@ module ApplicationHelper
   end
 
   def set_key(category = nil)
-    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+    if (category && current_page?(category_items_path(category))) || current_page?(history_items_path)
       :name
     elsif current_page?(categories_path)
       :title
@@ -46,15 +46,15 @@ module ApplicationHelper
   end
 
   def choice_page?(category = nil)
-    category && current_page?(category_items_path(category)) ||
-    current_page?(history_items_path) ||
-    current_page?(categories_path) ||
-    current_page?(posts_path) ||
-    current_page?(likes_posts_path)
+    (category && current_page?(category_items_path(category))) ||
+      current_page?(history_items_path) ||
+      current_page?(categories_path) ||
+      current_page?(posts_path) ||
+      current_page?(likes_posts_path)
   end
 
   def set_diposal_key(category = nil)
-    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+    if (category && current_page?(category_items_path(category))) || current_page?(history_items_path)
       :disposal_method_eq
     elsif current_page?(posts_path) || current_page?(likes_posts_path)
       :item_disposal_method_eq
@@ -62,7 +62,7 @@ module ApplicationHelper
   end
 
   def set_listing_key(category = nil)
-    if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
+    if (category && current_page?(category_items_path(category))) || current_page?(history_items_path)
       :listing_status_eq
     elsif current_page?(posts_path) || current_page?(likes_posts_path)
       :item_listing_status_eq

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
     if category && current_page?(category_items_path(category)) || current_page?(history_items_path)
       :name_cont
     elsif current_page?(categories_path)
-      :title_cont
+      :title_or_items_name_cont
     elsif current_page?(posts_path) || current_page?(likes_posts_path)
       :advice_cont
     end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,7 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
-
+application.register('autocomplete', Autocomplete)
 // Configure Stimulus development experience
 application.debug = false
 window.Stimulus   = application

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,4 +2,9 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :item
   has_many :likes, dependent: :destroy
+
+  ransacker :likes_count do
+    query = '(SELECT COUNT(*) FROM likes WHERE likes.post_id = posts.id)'
+    Arel.sql(query)
+  end
 end

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -6,7 +6,7 @@
       <%= render 'shared/crud_icon', object: category %>
     </div>
   </div>
-  <div class="collapse-content flex justify-between" data-controller="link" data-link-target="toLink" data-action="click->link#toLink" data-href="<%= items_path(category_id: category.id) %>"> 
+  <div class="collapse-content flex justify-between" data-controller="link" data-link-target="toLink" data-action="click->link#toLink" data-href="<%= category_items_path(category_id: category.id) %>"> 
     <p>hello</p>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 15l3-3m0 0l-3-3m3 3h-7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto w-full max-w-xl">
   <div class="flex justify-center mt-5 mb-10">
     <div data-controller="autocomplete" data-autocomplete-url-value="/categories/search" role="combobox">
-      <%= render "shared/search_form", url: categories_path, search_key: :title_cont, key: :title %>
+      <%= render "shared/search_form", url: categories_path, search_key: :title_cont, key: :title, date_key: 'items_notification_notify_date' %>
       <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
     </div>
   </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,6 +1,9 @@
 <div class="container mx-auto w-full max-w-xl">
-  <div class="flex justify-center my-5">
-    <%= render "shared/search_form", url: categories_path, search_key: :title_cont %>
+  <div class="flex justify-center mt-5 mb-10">
+    <div data-controller="autocomplete" data-autocomplete-url-value="/categories/search" role="combobox">
+      <%= render "shared/search_form", url: categories_path, search_key: :title_cont, key: :title %>
+      <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+    </div>
   </div>
   <div data-controller="graph" class="relative h-32">
     <canvas data-graph-target="bar"></canvas>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,10 +1,4 @@
 <div class="container mx-auto w-full max-w-xl">
-  <div class="flex justify-center mt-5 mb-10">
-    <div data-controller="autocomplete" data-autocomplete-url-value="/categories/search" role="combobox">
-      <%= render "shared/search_form", url: categories_path, search_key: :title_cont, key: :title, date_key: 'items_notification_notify_date' %>
-      <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
-    </div>
-  </div>
   <div data-controller="graph" class="relative h-32">
     <canvas data-graph-target="bar"></canvas>
   </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,4 +1,7 @@
 <div class="container mx-auto w-full max-w-xl">
+  <div class="flex justify-center my-5">
+    <%= render "shared/search_form", url: categories_path, search_key: :title_cont %>
+  </div>
   <div data-controller="graph" class="relative h-32">
     <canvas data-graph-target="bar"></canvas>
   </div>

--- a/app/views/categories/search.html.erb
+++ b/app/views/categories/search.html.erb
@@ -1,0 +1,5 @@
+<% @categories.each do |category| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 md:w-96" role="option" data-autocomplete-value="<%= category.id %>" data-autocomplete-label="<%= category.title %>">
+    <%= category.title %>
+  </li>
+<% end %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td class="w-1/2">
+  <td>
     <%= link_to item_path(item), class: "block py-2.5 px-4" do %>
       <div class="flex items-center space-x-5">
         <div class="avatar">
@@ -14,6 +14,16 @@
     <% end %>
   </td>
   <% if current_page?(history_items_path) %>
+    <td>
+      <div class="border">
+        <%= item.listing_status ? '出品中' : '未出品' %>
+      </div>
+    </td>
+    <td>
+      <div class="border">
+        <%= item.disposal_method_i18n %>
+      </div>
+    </td>
     <td>
       <%= link_to '投稿する', new_post_path(item_id: item.id), class: "btn" %>
     </td>

--- a/app/views/items/history.html.erb
+++ b/app/views/items/history.html.erb
@@ -1,4 +1,7 @@
 <div>
+  <div class="flex justify-center my-5">
+    <%= render "shared/search_form", url: history_items_path, search_key: :name_cont %>
+  </div>
   <div class="overflow-x-auto">
     <table class="table">
       <% if @disposal_items.present? %>

--- a/app/views/items/history.html.erb
+++ b/app/views/items/history.html.erb
@@ -1,6 +1,9 @@
 <div>
   <div class="flex justify-center my-5">
-    <%= render "shared/search_form", url: history_items_path, search_key: :name_cont %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="/items/search" role="combobox">
+      <%= render "shared/search_form", url: history_items_path, search_key: :name_cont, key: :name %>
+      <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+    </div>
   </div>
   <div class="overflow-x-auto">
     <table class="table">

--- a/app/views/items/history.html.erb
+++ b/app/views/items/history.html.erb
@@ -1,8 +1,13 @@
 <div>
+  <div role="tablist" class="tabs tabs-boxed justify-around" data-controller="tab">
+    <%= sort_link(@q_header, :name, '名前順', default_order: :desc, class: "tab", role: "tab") %>
+    <%= sort_link(@q_header, :updated_at, '新着順', default_order: :desc, class: "tab", role: "tab") %>
+    <%= sort_link(@q_header, :notification_notify_date, '通知日順', default_order: :desc, class: "tab", role: "tab") %>
+  </div>
   <div class="overflow-x-auto">
     <table class="table">
       <% if @disposal_items.present? %>
-        <%= render partial: 'item', collection: @disposal_items, locals: { item: @disposal_items } %>
+        <%= render partial: 'item', collection: @disposal_items %>
       <% end %>
     </table>
   </div>

--- a/app/views/items/history.html.erb
+++ b/app/views/items/history.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div class="flex justify-center my-5">
-    <div data-controller="autocomplete" data-autocomplete-url-value="/items/search" role="combobox">
+    <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_items_path(view: 'history') %>" role="combobox">
       <%= render "shared/search_form", url: history_items_path, search_key: :name_cont, key: :name %>
       <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
     </div>

--- a/app/views/items/history.html.erb
+++ b/app/views/items/history.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div class="flex justify-center my-5">
     <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_items_path(view: 'history') %>" role="combobox">
-      <%= render "shared/search_form", url: history_items_path, search_key: :name_cont, key: :name %>
+      <%= render "shared/search_form", url: history_items_path, search_key: :name_cont, key: :name, date_key: 'notification_notify_date' %>
       <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
     </div>
   </div>

--- a/app/views/items/history.html.erb
+++ b/app/views/items/history.html.erb
@@ -1,10 +1,4 @@
 <div>
-  <div class="flex justify-center my-5">
-    <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_items_path(view: 'history') %>" role="combobox">
-      <%= render "shared/search_form", url: history_items_path, search_key: :name_cont, key: :name, date_key: 'notification_notify_date' %>
-      <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
-    </div>
-  </div>
   <div class="overflow-x-auto">
     <table class="table">
       <% if @disposal_items.present? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div class="flex justify-center my-5">
     <!-- 検索フォーム -->
-    <%= render "shared/search_form", url: items_path, search_key: :name_cont %>
+    <%= render "shared/search_form", url: category_items_path(@category), search_key: :name_cont, key: :name %>
   </div>
   <div data-controller="tab">
     <div class="tabs">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,24 +1,30 @@
-<div data-controller="tab">
-  <div class="tabs">
-    <a class="tab w-1/2 tab-bordered tab-active" data-tab-target="status" data-action="click->tab#status">出品中</a> 
-    <a class="tab w-1/2 tab-bordered not-active" data-tab-target="status" data-action="click->tab#status">未出品</a> 
+<div>
+  <div class="flex justify-center my-5">
+    <!-- 検索フォーム -->
+    <%= render "shared/search_form", url: items_path, search_key: :name_cont %>
   </div>
-  <div data-tab-target="content">
-    <div class="overflow-x-auto">
-      <table class="table">
-        <% if @listed_items.present? %>
-          <%= render partial: 'item', collection: @listed_items, locals: { item: @listed_items } %>
-        <% end %>
-      </table>
+  <div data-controller="tab">
+    <div class="tabs">
+      <a class="tab w-1/2 tab-bordered tab-active" data-tab-target="status" data-action="click->tab#status">出品中</a> 
+      <a class="tab w-1/2 tab-bordered not-active" data-tab-target="status" data-action="click->tab#status">未出品</a> 
     </div>
-  </div>
-  <div class="hidden" data-tab-target="content">
-    <div class="overflow-x-auto">
-      <table class="table">
-        <% if @unlisted_items.present? %>
-          <%= render partial: 'item', collection: @unlisted_items, locals: { item: @unlisted_items } %>
-        <% end %>
-      </table>
+    <div data-tab-target="content">
+      <div class="overflow-x-auto">
+        <table class="table">
+          <% if @listed_items.present? %>
+            <%= render partial: 'item', collection: @listed_items %>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div class="hidden" data-tab-target="content">
+      <div class="overflow-x-auto">
+        <table class="table">
+          <% if @unlisted_items.present? %>
+            <%= render partial: 'item', collection: @unlisted_items %>
+          <% end %>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,24 +1,32 @@
-<div data-controller="tab">
-  <div class="tabs">
-    <a class="tab w-1/2 tab-bordered tab-active" data-tab-target="status" data-action="click->tab#status">出品中</a> 
-    <a class="tab w-1/2 tab-bordered not-active" data-tab-target="status" data-action="click->tab#status">未出品</a> 
+<div>
+  <div role="tablist" class="tabs tabs-boxed justify-around" data-controller="tab">
+    <%= sort_link(@q_header, :name, '名前順', default_order: :desc, class: "tab", role: "tab") %>
+    <%= sort_link(@q_header, :updated_at, '新着順', default_order: :desc, class: "tab", role: "tab") %>
+    <%= sort_link(@q_header, :created_at, '作成日順', { class: "tab", role: "tab"}) %>
+    <%= sort_link(@q_header, :notification_notify_date, '通知日順', default_order: :desc, class: "tab", role: "tab") %>
   </div>
-  <div data-tab-target="content">
-    <div class="overflow-x-auto">
-      <table class="table">
-        <% if @listed_items.present? %>
-          <%= render partial: 'item', collection: @listed_items %>
-        <% end %>
-      </table>
+  <div data-controller="tab">
+    <div class="tabs">
+      <a class="tab w-1/2 tab-bordered tab-active" data-tab-target="status" data-action="click->tab#status">出品中</a> 
+      <a class="tab w-1/2 tab-bordered not-active" data-tab-target="status" data-action="click->tab#status">未出品</a> 
     </div>
-  </div>
-  <div class="hidden" data-tab-target="content">
-    <div class="overflow-x-auto">
-      <table class="table">
-        <% if @unlisted_items.present? %>
-          <%= render partial: 'item', collection: @unlisted_items %>
-        <% end %>
-      </table>
+    <div data-tab-target="content">
+      <div class="overflow-x-auto">
+        <table class="table">
+          <% if @listed_items.present? %>
+            <%= render partial: 'item', collection: @listed_items %>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div class="hidden" data-tab-target="content">
+      <div class="overflow-x-auto">
+        <table class="table">
+          <% if @unlisted_items.present? %>
+            <%= render partial: 'item', collection: @unlisted_items %>
+          <% end %>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-center my-5">
     <!-- 検索フォーム -->
     <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_items_path(view: 'index') %>" role="combobox">
-      <%= render "shared/search_form", url: category_items_path(@category), search_key: :name_cont, key: :name %>
+      <%= render "shared/search_form", url: category_items_path(@category), search_key: :name_cont, key: :name, date_key: 'notification_notify_date' %>
       <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
     </div>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,10 @@
 <div>
   <div class="flex justify-center my-5">
     <!-- 検索フォーム -->
-    <%= render "shared/search_form", url: category_items_path(@category), search_key: :name_cont, key: :name %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_items_path(view: 'index') %>" role="combobox">
+      <%= render "shared/search_form", url: category_items_path(@category), search_key: :name_cont, key: :name %>
+      <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+    </div>
   </div>
   <div data-controller="tab">
     <div class="tabs">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,33 +1,24 @@
-<div>
-  <div class="flex justify-center my-5">
-    <!-- 検索フォーム -->
-    <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_items_path(view: 'index') %>" role="combobox">
-      <%= render "shared/search_form", url: category_items_path(@category), search_key: :name_cont, key: :name, date_key: 'notification_notify_date' %>
-      <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+<div data-controller="tab">
+  <div class="tabs">
+    <a class="tab w-1/2 tab-bordered tab-active" data-tab-target="status" data-action="click->tab#status">出品中</a> 
+    <a class="tab w-1/2 tab-bordered not-active" data-tab-target="status" data-action="click->tab#status">未出品</a> 
+  </div>
+  <div data-tab-target="content">
+    <div class="overflow-x-auto">
+      <table class="table">
+        <% if @listed_items.present? %>
+          <%= render partial: 'item', collection: @listed_items %>
+        <% end %>
+      </table>
     </div>
   </div>
-  <div data-controller="tab">
-    <div class="tabs">
-      <a class="tab w-1/2 tab-bordered tab-active" data-tab-target="status" data-action="click->tab#status">出品中</a> 
-      <a class="tab w-1/2 tab-bordered not-active" data-tab-target="status" data-action="click->tab#status">未出品</a> 
-    </div>
-    <div data-tab-target="content">
-      <div class="overflow-x-auto">
-        <table class="table">
-          <% if @listed_items.present? %>
-            <%= render partial: 'item', collection: @listed_items %>
-          <% end %>
-        </table>
-      </div>
-    </div>
-    <div class="hidden" data-tab-target="content">
-      <div class="overflow-x-auto">
-        <table class="table">
-          <% if @unlisted_items.present? %>
-            <%= render partial: 'item', collection: @unlisted_items %>
-          <% end %>
-        </table>
-      </div>
+  <div class="hidden" data-tab-target="content">
+    <div class="overflow-x-auto">
+      <table class="table">
+        <% if @unlisted_items.present? %>
+          <%= render partial: 'item', collection: @unlisted_items %>
+        <% end %>
+      </table>
     </div>
   </div>
 </div>

--- a/app/views/items/search.html.erb
+++ b/app/views/items/search.html.erb
@@ -1,0 +1,5 @@
+<% @items.each do |item| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= item.id %>" data-autocomplete-label="<%= item.name %>">
+    <%= item.name %>
+  </li>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,12 @@
-<div class="flex items-center justify-center md:flex flex-wrap">
-  <% if @posts.present? %>
-    <%= render @posts %>
-  <% else %>
-    <p class="text-center">投稿はありません</p>
-  <% end %>
+<div>
+  <div class="flex justify-center my-5">
+    <%= render "shared/search_form", url: posts_path, search_key: :advice_cont %>
+  </div>
+  <div class="flex items-center justify-center md:flex flex-wrap">
+    <% if @posts.present? %>
+      <%= render @posts %>
+    <% else %>
+      <p class="text-center">投稿はありません</p>
+    <% end %>
+  </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,10 @@
 <div>
+  <div role="tablist" class="tabs tabs-boxed justify-around" data-controller="tab">
+    <%= sort_link(@q_header, :likes_count, 'いいね順', default_order: :desc, class: "tab", role: "tab") %>
+    <%= sort_link(@q_header, :updated_at, '新着順', default_order: :desc, class: "tab", role: "tab") %>
+    <%= sort_link(@q_header, :created_at, '作成日順', default_order: :desc, class: "tab", role: "tab") %>
+  </div>
+  
   <div class="flex items-center justify-center md:flex flex-wrap">
     <% if @posts.present? %>
       <%= render @posts %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div class="flex justify-center my-5">
-    <%= render "shared/search_form", url: posts_path, search_key: :advice_cont %>
+    <%= render "shared/search_form", url: posts_path, search_key: :advice_cont, key: :advice %>
   </div>
   <div class="flex items-center justify-center md:flex flex-wrap">
     <% if @posts.present? %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,4 @@
 <div>
-  <div class="flex justify-center my-5">
-    <%= render "shared/search_form", url: posts_path, search_key: :advice_cont, key: :advice %>
-  </div>
   <div class="flex items-center justify-center md:flex flex-wrap">
     <% if @posts.present? %>
       <%= render @posts %>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,4 +1,7 @@
 <div class="container px-4">
+  <div class="flex justify-center my-5">
+    <%= render "shared/search_form", url: likes_posts_path, search_key: :advice_cont %>
+  </div>
   <div class="flex items-center justify-center md:flex flex-wrap">
     <% if @like_posts.present? %>
       <%= render @like_posts %>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,7 +1,4 @@
 <div class="container px-4">
-  <div class="flex justify-center my-5">
-    <%= render "shared/search_form", url: likes_posts_path, search_key: :advice_cont %>
-  </div>
   <div class="flex items-center justify-center md:flex flex-wrap">
     <% if @like_posts.present? %>
       <%= render @like_posts %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container w-full max-w-xl">
-  <h1 class="text-center mb-8">投稿詳細</h1>
+  <h2 class="text-center mb-8">投稿詳細</h2>
   <div class="flex justify-end">
   <% if current_user.own?(@post) %>
     <%= render "shared/crud_icon", object: @post %>
@@ -11,16 +11,27 @@
   <article class="card bg-base-100">
     <div class="card-body px-0 pt-0">
       <div>
-        <p class="bg-accent">断捨離したモノ</p>
+        <h2 class="bg-accent">断捨離したモノ</h2>
         <p class="card-title"><%= @post.item.name %></p>
         <figure><%= image_tag @post.item.image.url %></figure>
+        <h3><%= Category.human_attribute_name(:title) %></h3>
+        <p><%= @post.item.category.title %></p>
+
+        <h3><%= Item.human_attribute_name(:price) %></h3>
+        <p><%= @post.item.price %></p>
+
+        <h3><%= Item.human_attribute_name(:listing_status) %></h3>
+        <p><%= @post.item.listing_status ? '出品中' : '未出品' %></p>
+
+        <h3><%= Item.human_attribute_name(:disposal_method) %></h3>
+        <p><%= @post.item.disposal_method_i18n %></p>
       </div>
       <div>
-        <p class="bg-accent">お別れのことば</p>
+        <h2 class="bg-accent">お別れのことば</h2>
         <p><%= @post.content %></p>
       </div>
       <div>
-        <p class="bg-accent">みんなへのアドバイス</p>
+        <h2 class="bg-accent">みんなへのアドバイス</h2>
         <p><%= simple_format(@post.advice) %></p>
       </div>
     </div>

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -1,4 +1,4 @@
-<div class="btm-nav border-t border-gray-200">
+<div class="btm-nav border-t border-gray-200 z-40">
   <%= link_to new_category_path, data: { turbo_frame: "modal" } do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,12 +1,25 @@
 <!-- Navbar -->
 <div class="navbar bg-base-200">
-  <div class="flex-1">
+  <div class="navbar-start">
     <%= link_to "steteco", root_path, class: "btn btn-ghost normal-case text-xl" %>
   </div>
-  <div class="flex-none">
+  <% if choice_page?(@category) %>
+  <div class="navbar-center" data-controller="autocomplete" data-autocomplete-url-value=<%= set_value(@category) %> role="combobox">
+    <%= search_form_for @q_header, url: set_url(@category) do |f| %>
+      <div class="join">
+        <%= f.search_field set_search_key(@category), data: { autocomplete_target: 'input'}, class: "input input-bordered md:w-96 join-items", placeholder: "キーワード検索" %>
+        <%= f.hidden_field set_key(@category), data: { autocomplete_target: 'hidden' } %>
+      
+        <%= f.submit "検索", class: "btn btn-primary join-items" %>
+      </div>
+    <% end %>
+    <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+  </div>
+  <% end %>
+  <div class="navbar-end">
     <label for="my-drawer-3" aria-label="open sidebar" class="btn btn-ghost btn-circle avatar">
       <div class="w-10 rounded-full">
-        <%= image_tag "no_image.png" %>
+        <%= image_tag current_user.avatar.url %>
       </div>
     </label>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,28 +1,52 @@
 <!-- Navbar -->
-<div class="navbar bg-base-200">
-  <div class="navbar-start">
-    <%= link_to "steteco", root_path, class: "btn btn-ghost normal-case text-xl" %>
-  </div>
-  <% if choice_page?(@category) %>
-  <div class="navbar-center" data-controller="autocomplete" data-autocomplete-url-value=<%= set_value(@category) %> role="combobox">
-    <%= search_form_for @q_header, url: set_url(@category) do |f| %>
-      <div class="join">
-        <%= f.search_field set_search_key(@category), data: { autocomplete_target: 'input'}, class: "input input-bordered md:w-96 join-items", placeholder: "キーワード検索" %>
-        <%= f.hidden_field set_key(@category), data: { autocomplete_target: 'hidden' } %>
-      
-        <%= f.submit "検索", class: "btn btn-primary join-items" %>
+<div class="collapse bg-base-200">
+  <input type="checkbox" /> 
+  <div class="collapse-title flex justify-between">
+    <%= link_to "steteco", root_path, class: "btn btn-ghost normal-case text-xl z-40" %>
+    <% if choice_page?(@category) %>
+      <div class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+        </svg>
       </div>
     <% end %>
-    <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
-  </div>
-  <% end %>
-  <div class="navbar-end">
-    <label for="my-drawer-3" aria-label="open sidebar" class="btn btn-ghost btn-circle avatar">
+    <label for="my-drawer-3" aria-label="open sidebar" class="btn btn-ghost btn-circle avatar z-40">
       <div class="w-10 rounded-full">
         <%= image_tag current_user.avatar.url %>
       </div>
     </label>
   </div>
+  <% if choice_page?(@category) %>
+    <div class="collapse-content">
+      <div class="flex justify-center" data-controller="autocomplete" data-autocomplete-url-value=<%= set_value(@category) %> role="combobox">
+        <%= search_form_for @q_header, url: set_url(@category) do |f| %>
+          <div>
+            <%= f.search_field set_search_key(@category), data: { autocomplete_target: 'input'}, class: "input input-bordered md:w-96 join-items", placeholder: "キーワード検索" %>
+            <%= f.hidden_field set_key(@category), data: { autocomplete_target: 'hidden' } %>
+          </div>
+          <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+
+        <% if @category.present? && current_page?(category_items_path(@category)) || current_page?(history_items_path) %>
+          <div class="my-2">
+            <span>通知日で検索</span>
+            <%= f.date_field :notification_notify_date_gteq, class: "border" %>
+              <span>~</span>
+            <%= f.date_field :notification_notify_date_lteq_end_of_day, class: "border" %>
+          </div>
+        <% end %>
+        
+        <% if current_page?(posts_path) || current_page?(likes_posts_path) || current_page?(history_items_path) %>
+          <div class="flex justify-around">
+            <%= f.select set_listing_key, [['出品中', true], ['未出品', false]], include_blank: '出品状態で検索' %>
+            <%= f.select set_diposal_key, Item.disposal_methods_i18n.except(:before).invert.map { |key, value| [key, Item.disposal_methods[value]] }, { include_blank: "処分方法で検索" } %>
+          </div>
+        <% end %>
+          <div class="flex justify-center mt-2">
+            <%= f.submit "検索する", class: "btn btn-primary px-16" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>
-  
   

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,15 @@
 <%= search_form_for @q, url: url do |f| %>
-  <div class="join">
-    <%= f.search_field search_key, data: { autocomplete_target: 'input'}, class: "input input-bordered join-item md:w-96", placeholder: "入力して下さい" %>
-    <%= f.hidden_field key, data: { autocomplete_target: 'hidden' } %>
-    <%= f.submit "検索", class: "btn btn-primary join-item" %>
+  <div>
+    <div class="mb-5">
+      <%= f.date_field :"#{date_key}_gteq", class: "border" %>
+      <span>~</span>
+      <%= f.date_field :"#{date_key}_lteq_end_of_day", class: "border" %>
+    </div>
+    <div class="join">
+      <%= f.search_field search_key, data: { autocomplete_target: 'input'}, class: "input input-bordered md:w-96 join-items", placeholder: "キーワード検索" %>
+      <%= f.hidden_field key, data: { autocomplete_target: 'hidden' } %>
+
+      <%= f.submit "検索", class: "btn btn-primary join-items" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,6 +1,7 @@
 <%= search_form_for @q, url: url do |f| %>
   <div class="join">
-    <%= f.search_field search_key, class: "input input-bordered join-item md:w-96", placeholder: "入力して下さい" %>
+    <%= f.search_field search_key, data: { autocomplete_target: 'input'}, class: "input input-bordered join-item md:w-96", placeholder: "入力して下さい" %>
+    <%= f.hidden_field key, data: { autocomplete_target: 'hidden' } %>
     <%= f.submit "検索", class: "btn btn-primary join-item" %>
   </div>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,15 +1,8 @@
 <%= search_form_for @q, url: url do |f| %>
-  <div>
-    <div class="mb-5">
-      <%= f.date_field :"#{date_key}_gteq", class: "border" %>
+  <div class="mb-5">
+    <%= f.date_field :"#{date_key}_gteq", class: "border" %>
       <span>~</span>
-      <%= f.date_field :"#{date_key}_lteq_end_of_day", class: "border" %>
-    </div>
-    <div class="join">
-      <%= f.search_field search_key, data: { autocomplete_target: 'input'}, class: "input input-bordered md:w-96 join-items", placeholder: "キーワード検索" %>
-      <%= f.hidden_field key, data: { autocomplete_target: 'hidden' } %>
-
-      <%= f.submit "検索", class: "btn btn-primary join-items" %>
-    </div>
+    <%= f.date_field :"#{date_key}_lteq_end_of_day", class: "border" %>
   </div>
+    <%= f.submit "検索", class: "btn btn-primary join-items" %>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @q, url: url do |f| %>
-  <div class"join>
-    <%= f.search_field :name_or_price_cont, class: "input input-bordered join-item", placeholder: "入力して下さい" %>
+  <div class="join">
+    <%= f.search_field search_key, class: "input input-bordered join-item md:w-96", placeholder: "入力して下さい" %>
     <%= f.submit "検索", class: "btn btn-primary join-item" %>
   </div>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,6 @@
+<%= search_form_for @q, url: url do |f| %>
+  <div class"join>
+    <%= f.search_field :name_or_price_cont, class: "input input-bordered join-item", placeholder: "入力して下さい" %>
+    <%= f.submit "検索", class: "btn btn-primary join-item" %>
+  </div>
+<% end %>

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,5 +1,5 @@
 Ransack.configure do |config|
   config.add_predicate 'lteq_end_of_day',
-                  arel_predicate: 'lteq',
-                  formatter: proc { |v| v.end_of_day }
+                       arel_predicate: 'lteq',
+                       formatter: proc { |v| v.end_of_day }
 end

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,5 @@
+Ransack.configure do |config|
+  config.add_predicate 'lteq_end_of_day',
+                  arel_predicate: 'lteq',
+                  formatter: proc { |v| v.end_of_day }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,14 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root to: 'homes#top'
   resources :users, only: [:new, :create, :show, :edit, :update]
-  resources :categories, except: :show
+  resources :categories, except: :show do
+    get 'search', on: :collection
+  end
   resources :items do
     collection do
       get 'history'
       get 'chart'
+      get 'search'
     end
   end
   resources :posts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
     end
   end
   resources :posts do
-    get 'likes', on: :collection
+    collection do
+      get 'likes'
+      get 'search'
+    end
   end
   resources :likes, only: [:create, :destroy]
   resources :declutterings, only: [:edit, :update, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,6 @@ Rails.application.routes.draw do
   resources :posts do
     collection do
       get 'likes'
-      get 'search'
     end
   end
   resources :likes, only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,10 @@ Rails.application.routes.draw do
   root to: 'homes#top'
   resources :users, only: [:new, :create, :show, :edit, :update]
   resources :categories, except: :show do
+    resources :items, only: :index
     get 'search', on: :collection
   end
-  resources :items do
+  resources :items, except: :index do
     collection do
       get 'history'
       get 'chart'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "daisyui": "^3.9.2",
     "esbuild": "^0.19.4",
     "postcss": "^8.4.31",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.3.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,6 +718,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 sucrase@^3.32.0:
   version "3.34.0"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.34.0.tgz#1e0e2d8fcf07f8b9c3569067d92fbd8690fb576f"


### PR DESCRIPTION
## 概要
- ransackによる検索機能とソート機能
- カテゴリー一覧・捨てたもの履歴・アイテム一覧・投稿一覧・お気に入り一覧ページに検索フォームを設定
- 検索フォームはヘッダーを折りたたみにし、折りたたみのコンテンツ部分に設置
- 検索の種類はページごとに切り替えている
- ソート機能はransackのsort_linkを使用
- ソート機能は捨てたもの履歴・アイテム一覧・投稿一覧ページに設定
- ページごとに並び替えの種類を切り替え
- viewでの表示切り替えはヘルパーメソッドを作成してコードを削減
- 検索機能には、stimulus-autocompleteを使用
- rubocopチェックでコード修正

## メモ
postのsearchアクションは、現時点の検索内容だとオートコンプリートは必要ないため一旦削除。
カテゴリー検索は後から追加を試してみる。（タグ機能を追加できたらタグ検索も）
いいね数の表示は次のブランチで必ず行う。
counter_cultureの導入を検討