### PR TITLE
概要：Fix upload post

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -14,7 +14,7 @@ class OauthsController < ApplicationController
         @user = create_from(provider)
         reset_session
         auto_login(@user)
-        redirect_to "https://line.me/R/ti/p/%40305zhajm", notice: "#{provider.titleize}でログインしました"
+        redirect_to categories_path, notice: "#{provider.titleize}でログインしました"
       rescue StandardError
         redirect_to root_path, alert: "#{provider.titleize}でのログインに失敗しました"
       end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,9 @@ class PostsController < ApplicationController
 
   def index
     # distinct: trueではsort_linkでエラーになるため
-    @posts = @q_header.result.group('posts.id').includes([:user, :likes, :item]).order(created_at: :desc) if @q_header
+    @posts = @q_header.result.group('posts.id').joins(:item)
+                             .where.not(items: { disposal_method: 0 }).includes([:user, :likes])
+                             .order(created_at: :desc) if @q_header
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
                                ["items.disposal_method = ?", "before"] => 'items_count'
                              }
 
-  has_one :post, dependent: :destroy
+  has_many :posts, dependent: :destroy
   has_one :notification, dependent: :destroy
   accepts_nested_attributes_for :notification, allow_destroy: true
 

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-center">
     <%= f.label :image do %>
       <%= image_tag item.image.url, id: "preview", class: "w-20 md:w-32 lg:w-40" %>
-      <%= f.file_field :image, onchange: "previewFileWithId('preview')", accept: "image/*", capture: "camera", class: "hidden" %>
+      <%= f.file_field :image, onchange: "previewFileWithId('preview')", accept: "image/*", class: "hidden" %>
       <%= f.hidden_field :image_cache %>
     <% end %>
   </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -7,7 +7,7 @@
     <div class="flex justify-center">
       <%= f.label :post_image do %>
         <%= image_tag post.post_image.url, id: "preview", class: "w-[250px] md:w-80" %>
-        <%= f.file_field :post_image, onchange: "previewFileWithId('preview')", accept: "image/*", capture: "camera", class: "hidden" %>
+        <%= f.file_field :post_image, onchange: "previewFileWithId('preview')", accept: "image/*", class: "hidden" %>
         <%= f.hidden_field :post_image_cache %>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要

- upload機能に関して、以前のコードだとカメラしか機能しなかったため、capture: cameraを削除することでファイルかカメラか選択できるように変更
- 投稿一覧を処分後のアイテムに関する投稿のみを表示するように変更
- 元は一つのアイテムに対して一つの投稿ができるようにhas_oneで設定していたが、has_one設定をしても一つのアイテムに対して複数の投稿ができてしまったので、一旦has_manyに修正。コントローラかテーブルの設定の変更が必要と予想しているが、複数投稿できても問題がないようなら、そのままhas_manyにする予定。
- その他軽微な修正

## メモ

- スマホだと、日付カレンダーのリセットが機能しない、原因を確認する
- スマホだと、プレビュー画像の削除ができない