### PR TITLE
概要：Fix memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
-  gem "pry-byebug"
   gem "rspec-rails"
   gem "factory_bot_rails"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.39.2)
       addressable
       matrix
@@ -94,7 +93,6 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
-    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     config (4.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -256,12 +254,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
     psych (5.1.0)
       stringio
     public_suffix (5.0.3)
@@ -430,7 +422,6 @@ DEPENDENCIES
   line-bot-api
   mini_magick
   pg (~> 1.1)
-  pry-byebug
   puma (~> 5.0)
   rails (= 7.0.6)
   rails-i18n

--- a/crontab
+++ b/crontab
@@ -1,1 +1,1 @@
-0 7 * * * bundle exec rake /rails/lib/tasks/push_line.rake push_line_message_notify_date
+*/5 * * * * bundle exec rake /rails/lib/tasks/push_line.rake push_line_message_notify_date


### PR DESCRIPTION
## 概要

- アプリのメモリが多くデプロイ先でクラッシュしてしまったので、使っていないgemを削除
- line通知が届かなかったため、原因を調査するためcrontabの設定を一旦変更