### PR TITLE
レコメンドアイテムを平均値の高さで取得するように変更

### DIFF
--- a/app/controllers/concerns/textpair_api.rb
+++ b/app/controllers/concerns/textpair_api.rb
@@ -18,7 +18,7 @@ module TextpairApi
       # ハッシュオブジェクト[キー] = 値で新しい要素を追加
       similarity_hash[user_item_id] = similarities
     end
-    similarity_hash
+    return similarity_hash
   end
 
   def post_text(text1, text2)
@@ -34,7 +34,7 @@ module TextpairApi
     begin
       res = http.request(req)
       req_result = JSON.parse(res.body)
-      req_result["score"]
+      return req_result["score"]
     rescue Net::ReadTimeout, Net::OpenTimeout
       nil
     end


### PR DESCRIPTION
## 概要

- レコメンドのロジックをapiの数値のカウント数でアイテムを選択していたのを平均値に変更。
- カウント数だと0.6以上の数値が複数ある場合、ランダムで選択するように設定しているので数値が低いものが選ばれてしまう可能性があるため。

## メモ

- 平均値でも、値の数によって公平性にばらつきが出てしまうので、今度も他の方法がないか検討。